### PR TITLE
Allow ReadonlySignal on useSignalValue hook

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,7 +1,7 @@
-import { Signal, computed, effect } from "@preact/signals-core";
+import { ReadonlySignal, Signal, computed, effect } from "@preact/signals-core";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-export function useSignalValue<T>(signal: Signal<T>): T {
+export function useSignalValue<T>(signal: ReadonlySignal<T>): T {
   const [state, setState] = useState<T>(signal.value);
   useEffect(() => {
     return effect(() => setState(signal.value));


### PR DESCRIPTION
Currently, the input parameter of `useSignalValue` is `Signal<T>`, but this is unnecessarily specific. The signal might as well be a computed signal, since the hook never writes to the signal. So `ReadonlySignal<T>` is a more general purpose type here and makes the hook more generally useful.

Thank you for this really simple and elegant solution to using signals in React. I've been having all kinds of problems with `@preact/signals-react` and this came in as a lifesaver.